### PR TITLE
Updated README to remove version and extra `.`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can find examples of iOS & Android apps showcasing a Purchasely implementati
 
 ## Setting up the extension
 
-To setup the extension, visit **[https://console.firebase.google.com/project/_/extensions/install?ref=purchasely/purchasely-in-app-purchases@1.0.0](https://console.firebase.google.com/project/_/extensions/install?ref=purchasely/purchasely-in-app-purchases@1.0.0)**.
+To setup the extension, visit **[https://console.firebase.google.com/project/_/extensions/install?ref=purchasely/purchasely-in-app-purchases](https://console.firebase.google.com/project/_/extensions/install?ref=purchasely/purchasely-in-app-purchases)**
 
 #### Additional setup
 


### PR DESCRIPTION
Removed version so that the link always points to the latest version, and removed `.` so that if someone copy-pastes (instead of clicking on the link) they don't end up with extra `.` which breaks the Firebase install UI.