### PR TITLE
fix(deps): force transitive uuid >=11.1.1 in functions (CVE-2026-41907)

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1501,10 +1501,9 @@
       }
     },
     "node_modules/@google-cloud/firestore/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -1512,7 +1511,7 @@
       "license": "MIT",
       "optional": true,
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@google-cloud/paginator": {
@@ -6679,10 +6678,9 @@
       }
     },
     "node_modules/gaxios/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6690,7 +6688,7 @@
       "license": "MIT",
       "optional": true,
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/gcp-metadata": {
@@ -10840,10 +10838,9 @@
       }
     },
     "node_modules/teeny-request/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -10851,7 +10848,7 @@
       "license": "MIT",
       "optional": true,
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/temp-dir": {
@@ -12679,7 +12676,7 @@
             "proto3-json-serializer": "^2.0.2",
             "protobufjs": "^7.3.2",
             "retry-request": "^7.0.0",
-            "uuid": "^9.0.1"
+            "uuid": "^11.1.1"
           }
         },
         "proto3-json-serializer": {
@@ -12692,9 +12689,9 @@
           }
         },
         "uuid": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+          "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
           "optional": true
         }
       }
@@ -16363,7 +16360,7 @@
         "https-proxy-agent": "^7.0.1",
         "is-stream": "^2.0.0",
         "node-fetch": "^2.6.9",
-        "uuid": "^9.0.1"
+        "uuid": "^11.1.1"
       },
       "dependencies": {
         "agent-base": {
@@ -16386,9 +16383,9 @@
           }
         },
         "uuid": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+          "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
           "optional": true
         }
       }
@@ -19297,13 +19294,13 @@
         "https-proxy-agent": "^5.0.0",
         "node-fetch": "^2.6.9",
         "stream-events": "^1.0.5",
-        "uuid": "^9.0.0"
+        "uuid": "^11.1.1"
       },
       "dependencies": {
         "uuid": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+          "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
           "optional": true
         }
       }

--- a/functions/package.json
+++ b/functions/package.json
@@ -51,7 +51,16 @@
     "tslint": "^6.1.3"
   },
   "overrides": {
-    "fast-xml-parser": ">=5.3.8"
+    "fast-xml-parser": ">=5.3.8",
+    "@google-cloud/firestore": {
+      "uuid": "^11.1.1"
+    },
+    "gaxios": {
+      "uuid": "^11.1.1"
+    },
+    "teeny-request": {
+      "uuid": "^11.1.1"
+    }
   },
   "private": true,
   "ava": {


### PR DESCRIPTION
## Why

Vanta / Dependabot alert **#356** (GHSA-w5hq-g745-h8pq, uuid < 11.1.1) stayed open on `functions/package-lock.json` despite the earlier fix in #474.

Root cause:
- The **direct** `uuid` dependency is already `14.0.1` (safe), but `@google-cloud/firestore`, `gaxios` and `teeny-request` pulled **uuid `9.0.1` transitively** — still vulnerable.
- #474 added the `uuid` override to the **root** `package.json`, which does not govern the separate `functions/` npm project, and its hand-edited lockfile bumps were reverted when a later `npm install` (#475, same day) regenerated `functions/package-lock.json`.

## Fix

Scope the override to the three offending parents in `functions/package.json`, pinning transitive uuid to `^11.1.1`:

```json
"overrides": {
  "fast-xml-parser": ">=5.3.8",
  "@google-cloud/firestore": { "uuid": "^11.1.1" },
  "gaxios": { "uuid": "^11.1.1" },
  "teeny-request": { "uuid": "^11.1.1" }
}
```

A top-level `"uuid"` override is rejected by npm (`EOVERRIDE`) because it conflicts with the direct `^14.0.0`. Pinning to 11.1.x (not 14.x) also keeps the CJS-compatible line these Google libs are built against.

After regeneration, all runtime uuid nodes are ≥ 11.1.1 (direct stays 14.0.1); `@types/uuid` is unrelated (type defs).

## Validation

- `npm install` clean, `npm run build` (tsc) ✅
- `npm test` (c8 + ava) ✅ green locally on Node 22

Closes Dependabot alert #356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)