### PR TITLE
fix: force brace-expansion >=5.0.7 in cacache to close high CVE (Vanta Dependabot)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1976,11 +1976,10 @@
       }
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -9474,9 +9473,9 @@
           "optional": true
         },
         "brace-expansion": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-          "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+          "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -9509,7 +9508,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "brace-expansion": "^5.0.2"
+            "brace-expansion": "^5.0.7"
           }
         },
         "path-scurry": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "firebase-tools": "^15.24.0"
   },
   "overrides": {
-    "uuid": "^11.1.1"
+    "uuid": "^11.1.1",
+    "cacache": {
+      "brace-expansion": "^5.0.7"
+    }
   }
 }


### PR DESCRIPTION
## What

Adds a scoped npm `overrides` entry so **cacache**'s subtree resolves **brace-expansion** to `^5.0.7`. cacache (pulled via `firebase-tools` → `make-fetch-happen`) resolved `brace-expansion@5.0.4`, flagged by Dependabot as **CVE-2026-13149 / GHSA-3jxr-9vmj-r5cp** (high — ReDoS / exponential-time `expand()`). Lockfile now resolves `5.0.7`.

## Why

Closes the Vanta test [High vulnerabilities identified in packages are addressed (GitHub Repo)](https://app.vanta.com/c/purchasely.com/tests/packages-checked-for-vulnerabilities-v2-records-closed-github-dependabot-high) finding for `Purchasely-Firebase-Extension` (Dependabot #391).

## Scope / why scoped

The override is nested under `cacache` on purpose. The advisory maintains separate patched lines (1.1.16, 2.1.2, 5.0.7), so a blanket top-level override to `5.x` would risk forcing the 5.x major onto the 1.x/2.x consumers (`minimatch` line) — which are **not** in the flagged `>=3.0.0 <5.0.7` range. Only cacache's `5.0.4` was vulnerable.

- `package.json` — add nested `overrides.cacache.brace-expansion`
- `package-lock.json` — regenerated; `cacache/node_modules/brace-expansion` 5.0.4 → 5.0.7, other lines untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)