### PR TITLE
fix: add tar >=7.5.18 override to close medium CVE (Vanta Dependabot)

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -10797,9 +10797,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "dev": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -13222,7 +13222,7 @@
         "node-fetch": "^2.6.7",
         "nopt": "^8.0.0",
         "semver": "^7.5.3",
-        "tar": "^7.4.0"
+        "tar": "^7.5.18"
       },
       "dependencies": {
         "abbrev": {
@@ -19264,9 +19264,9 @@
       }
     },
     "tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "dev": true,
       "requires": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -52,6 +52,7 @@
   },
   "overrides": {
     "fast-xml-parser": ">=5.3.8",
+    "tar": "^7.5.18",
     "@google-cloud/firestore": {
       "uuid": "^11.1.1"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7258,9 +7258,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "dev": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -10705,7 +10705,7 @@
         "stream-chain": "^2.2.4",
         "stream-json": "^1.7.3",
         "superstatic": "^10.0.0",
-        "tar": "^7.5.11",
+        "tar": "^7.5.18",
         "tcp-port-used": "^1.0.2",
         "tmp": "^0.2.3",
         "triple-beam": "^1.3.0",
@@ -12204,7 +12204,7 @@
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "tar": "^7.5.2",
+        "tar": "^7.5.18",
         "tinyglobby": "^0.2.12",
         "which": "^6.0.0"
       },
@@ -13429,9 +13429,9 @@
       }
     },
     "tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "dev": true,
       "requires": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "overrides": {
     "uuid": "^11.1.1",
+    "tar": "^7.5.18",
     "cacache": {
       "brace-expansion": "^5.0.7"
     }


### PR DESCRIPTION
## What

Adds a top-level npm `overrides.tar = ^7.5.18` in **both** `package.json` (root) and `functions/package.json`. tar resolved to `7.5.16` in both trees, flagged by Dependabot for **CVE-2026-59871** / GHSA-w8wr-v893-vjvp (PAX numeric-path extraction DoS, fix 7.5.18):
- root `package-lock.json` (via `firebase-tools` / `node-gyp`) · Dependabot #404
- `functions/package-lock.json` (via `@mapbox/node-pre-gyp`) · Dependabot #396

Both lockfiles now resolve `7.5.20`.

## Why

Closes the two `Purchasely-Firebase-Extension` `tar` findings on the Vanta test [Medium vulnerabilities identified in packages are addressed (GitHub Repo)](https://app.vanta.com/c/purchasely.com/tests/packages-checked-for-vulnerabilities-v2-records-closed-github-dependabot-medium).

All tar consumers here are on the 7.x line, so a top-level override is safe (no cross-major forcing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)