### PR TITLE
chore(deps): close brace-expansion HIGH CVEs in root lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1900,16 +1900,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -2006,16 +1996,17 @@
       }
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/cacache/node_modules/glob": {
@@ -3985,6 +3976,16 @@
         "toxic": "^1.0.0"
       }
     },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/glob/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -5287,9 +5288,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6524,6 +6525,16 @@
         "minimatch": "^5.1.0"
       }
     },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/readdir-glob/node_modules/minimatch": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
@@ -7231,6 +7242,16 @@
       },
       "optionalDependencies": {
         "re2": "^1.17.7"
+      }
+    },
+    "node_modules/superstatic/node_modules/brace-expansion": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/superstatic/node_modules/commander": {
@@ -9445,15 +9466,6 @@
         "wrap-ansi": "^7.0.0"
       }
     },
-    "brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -9519,9 +9531,9 @@
           "optional": true
         },
         "brace-expansion": {
-          "version": "5.0.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-          "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+          "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -9554,7 +9566,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "brace-expansion": "^5.0.7"
+            "brace-expansion": "^5.0.8"
           }
         },
         "path-scurry": {
@@ -10972,13 +10984,22 @@
         "path-scurry": "^1.11.1"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+          "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "minimatch": {
           "version": "9.0.9",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
           "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^2.0.2"
+            "brace-expansion": "^2.1.2"
           }
         }
       }
@@ -11965,13 +11986,13 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^1.1.16"
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+          "version": "1.1.16",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+          "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -12916,13 +12937,22 @@
         "minimatch": "^5.1.0"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+          "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "minimatch": {
           "version": "5.1.9",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
           "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^2.0.1"
+            "brace-expansion": "^2.1.2"
           }
         }
       }
@@ -13438,6 +13468,15 @@
         "update-notifier-cjs": "^5.1.6"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+          "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "commander": {
           "version": "10.0.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -13450,7 +13489,7 @@
           "integrity": "sha512-5rvZbDy5y2k40rre/0OBbYnl03en25XPU3gOVO7532beGMjAipq88VdS9OeLOZNrD+Tb0lDhBJHZ7Gcd8qKlPg==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^2.0.1"
+            "brace-expansion": "^2.1.2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "uuid": "^11.1.1",
     "tar": "^7.5.18",
     "cacache": {
-      "brace-expansion": "^5.0.7"
-    }
+      "brace-expansion": "^5.0.8"
+    },
+    "brace-expansion@1": "^1.1.16",
+    "brace-expansion@2": "^2.1.2"
   }
 }


### PR DESCRIPTION
## Why

Vanta SOC 2 test `packages-checked-for-vulnerabilities-v2-records-closed-github-dependabot-high` is failing. Findings here:

- [#399](https://github.com/Purchasely/Purchasely-Firebase-Extension/security/dependabot/399) — `brace-expansion < 1.1.16`, CVE-2026-13149 (HIGH, ReDoS), via `firebase-tools → minimatch@3.1.5`
- [#400](https://github.com/Purchasely/Purchasely-Firebase-Extension/security/dependabot/400) — `brace-expansion >= 2.0.0, < 2.1.2`, same CVE, via `glob` / `readdir-glob` / `superstatic`

## What

Line-scoped overrides, same pattern as the existing `cacache` entry:

```json
"overrides": {
  "brace-expansion@1": "^1.1.16",
  "brace-expansion@2": "^2.1.2",
  "cacache": { "brace-expansion": "^5.0.8" }
}
```

Why not one blanket `brace-expansion: ^5.0.8`: v5 replaced the CJS default export (`module.exports = expandTop`) with a named `expand` export, so forcing it onto the `minimatch` 3/5/6/9 consumers in this tree would throw at runtime. The advisory backports each line separately, so per-line pins are the correct fix.

The `cacache` bump (`^5.0.7` → `^5.0.8`) closes CVE-2026-14257 on the same package before it gets its own alert.

Resulting versions: `minimatch/brace-expansion 1.1.16`, `glob|readdir-glob|superstatic → 2.1.3`, `cacache → 5.0.8`. Root manifest only (tooling / deploy), `functions/` untouched.

## Verification

- `npm ci` → clean
- `./node_modules/.bin/firebase --version` → `15.24.0` (CLI boots)
- `require('minimatch')` smoke test → ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)